### PR TITLE
Add entry about unlimited const evaluation

### DIFF
--- a/posts/2023-08-24-Rust-1.72.0.md
+++ b/posts/2023-08-24-Rust-1.72.0.md
@@ -19,6 +19,25 @@ If you'd like to help us out by testing future releases, you might consider upda
 
 ## What's in 1.72.0 stable
 
+### Const evaluation time is now unlimited
+
+To prevent user-provided const evaluation from getting into a compile-time
+infinite loop or otherwise taking unbounded time at compile time, Rust
+previously limited the maximum number of *statements* run as part of any given
+constant evaluation. However, especially creative Rust code could hit these
+limits and produce a compiler error. Worse, whether code hit the limit could
+vary wildly based on libraries invoked by the user; if a library you invoked
+split a statement into two within one of its functions, your code could then
+fail to compile.
+
+Now, you can do an unlimited amount of const evaluation at compile time, To
+avoid having long compilations without feedback, the compiler will always emit
+a message after your compile-time code has been running for a while, and repeat
+that message after a period that doubles each time. By default, the compiler
+will also emit a deny-by-default lint (`const_eval_long_running`) after a large
+number of steps to catch infinite loops, but you can
+`allow(const_eval_long_running)` to permit especially long const evaluation.
+
 ### Uplifted lints from Clippy
 
 Several lints from Clippy have been pulled into `rustc`:


### PR DESCRIPTION
Add a section about the new unlimited const evaluation in Rust 1.72.0.
